### PR TITLE
react-jenkins-day-demo to 0.0.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -24,4 +24,4 @@ dependencies:
   version: 0.0.3
 - name: react-jenkins-day-demo
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.3
+  version: 0.0.6


### PR DESCRIPTION
Promote react-jenkins-day-demo to version 0.0.6